### PR TITLE
Fix ethminer entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,4 +45,4 @@ ENV GPU_USE_SYNC_OBJECTS=1
 ENV GPU_MAX_ALLOC_PERCENT=100
 ENV GPU_SINGLE_ALLOC_PERCENT=100
 
-ENTRYPOINT ["/cpp-ethereum/build/ethminer/ethminer", "-U"]
+ENTRYPOINT ["/usr/local/bin/ethminer", "-U"]


### PR DESCRIPTION
After changing to ethminer the `ENTRYPOINT` in the `Dockerfile` is broken (at least for me). This fixes it.